### PR TITLE
Use sh as default shell to open in containers

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -113,7 +113,7 @@ var runCommand = async (command, containerName, callback) => {
         "-e",
         "bash",
         "-c",      
-        "'docker exec -it " + containerName + " bash; exec $SHELL'"
+        "'docker exec -it " + containerName + " sh; exec $SHELL'"
       ];
       GLib.spawn_command_line_async(cmd.join(" "));
       break;


### PR DESCRIPTION
This makes it work with Alpine based containers, too. One can still run `bash` inside the container if they like.
As Alpine Linux has an exceptionally small footprint, it is a popular choice for Docker containers. It doesn't have Bash by default, so opening a shell via the extension caused an error.