### PR TITLE
Fix ps binary path

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -39,7 +39,7 @@ var isUserInDockerGroup = (() => {
  * @return {Boolean} whether docker daemon is running or not
  */
 var isDockerRunning = async () => {
-  const cmdResult = await execCommand(["/bin/ps", "cax"]);  
+  const cmdResult = await execCommand(["ps", "cax"]);
   return cmdResult.search(/dockerd/) >= 0;
 };
 


### PR DESCRIPTION
`/bin/ps` prevent this extension to work on every system where `ps` is located elsewhere (Nixos for example). 
There is no real need to specify `/bin`.