### PR TITLE
Allow install in Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "description": "A GNOME Shell extension (GNOME Panel applet) to be able to generally control your available Docker containers.",
   "url": "https://github.com/RedSoftwareSystems/easy_docker_containers",
   "version": 18,
-  "shell-version": ["3.34", "3.36", "3.38", "40", "41", "42"]
+  "shell-version": ["3.34", "3.36", "3.38", "40", "41", "42", "43"]
 }


### PR DESCRIPTION
The extension works on Gnome 43, so enable for this version.