### PR TITLE
Remove down-arrow between icon and counter

### DIFF
--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -52,7 +52,6 @@ var DockerMenu = GObject.registerClass(
       });
 
       hbox.add_child(dockerIcon);
-      hbox.add_child(arrowIcon(St.Side.BOTTOM));
       hbox.add_child(this.buttonText);
       this.add_child(hbox);
       this.menu.connect("open-state-changed", this._refreshMenu.bind(this));


### PR DESCRIPTION
The arrow icon between the Docker icon and the container counter is just unneeded visual clutter.

It would be nice if we could get rid of it.