### PR TITLE
[feat] Add a menu entry to stop all running containers.

### DIFF
--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -16,9 +16,9 @@ import {getExtensionObject} from "../extension.js";
  *
  * @return {Object} an St.Icon instance
  */
-const gioIcon = (name = "docker-container-unavailable-symbolic") =>
+export const gioIcon = (name = "docker-container-unavailable-symbolic") =>
   Gio.icon_new_for_string(getExtensionObject().path + "/icons/" + name + ".svg");
-const menuIcon = (
+export const menuIcon = (
   name = "docker-container-unavailable-symbolic",
   styleClass = "system-status-icon"
 ) =>
@@ -35,7 +35,7 @@ const menuIcon = (
  *
  * @return {String} The status in ['running', 'paused', 'stopped']
  */
-const getStatus = (statusMessage) => {
+export const getStatus = (statusMessage) => {
   let status = "stopped";
   if (statusMessage.indexOf("Up") > -1) status = "running";
   if (statusMessage.indexOf("Paused") > -1) status = "paused";


### PR DESCRIPTION
Hi,

this is a simple update to allow the user to stop all running containers at once.
The menu is disabled if no container is running.

![image](https://github.com/RedSoftwareSystems/easy_docker_containers/assets/64325154/6a2d8c7d-805b-43eb-99d5-ce15966d81f6)


I've made a few changes as possible, but some existing functions I've used may required to be moved to their own file, like _utils.js_ or so

Hope you can find the time to review this PR.