### PR TITLE
Allow install in GNOME 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "url": "https://github.com/RedSoftwareSystems/easy_docker_containers",
   "version": 21,
   "settings-schema": "red.software.systems.easy_docker_containers",
-  "shell-version": ["45"]
+  "shell-version": ["45", "46"]
 }


### PR DESCRIPTION
The extension is working on [GNOME 46](https://release.gnome.org/46/developers/index.html), so it can be allowed without any changes. 