### PR TITLE
Fix extension in GNOME 46

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -131,7 +131,7 @@ export const runCommand = async (command, containerName, callback) => {
     const errMsg = `No valid terminal found (${Object.keys(validTerminals).join(
       ", "
     )})`;
-    Main.notify(errMsg);
+    Main.notify("Error", errMsg);
     logError(err);
     return;
   }

--- a/src/docker.js
+++ b/src/docker.js
@@ -84,7 +84,7 @@ export const getContainers = async () => {
 
 /**
  * Get the number of containers
- * @return {Number} The number of running containers
+ * @return {Promise<Number>} The number of running containers
  */
 export const getContainerCount = async () => {
   const psOut = await execCommand([

--- a/src/docker.js
+++ b/src/docker.js
@@ -150,7 +150,7 @@ export const runCommand = async (command, containerName, callback) => {
       break;
     default:
       cmd = ["docker", command, containerName];
-      execCommand(cmd, callback);
+      return execCommand(cmd, callback);
   }
 };
 
@@ -159,7 +159,6 @@ export async function execCommand(
   callback /*(status, command, err) */,
   cancellable = null
 ) {
-  let execProm = null;
   try {
     // There is also a reusable Gio.SubprocessLauncher class available
     let proc = new Gio.Subprocess({
@@ -175,7 +174,7 @@ export async function execCommand(
     // If the class implements GAsyncInitable then Class.new_async() could
     // also be used and awaited in a Promise.
     proc.init(null);
-    execProm = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // communicate_utf8() returns a string, communicate() returns a
       // a GLib.Bytes and there are "headless" functions available as well
       proc.communicate_utf8_async(null, cancellable, (proc, res) => {
@@ -202,5 +201,4 @@ export async function execCommand(
     logError(e);
     throw e;
   }
-  return execProm;
 }

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -63,7 +63,7 @@ export const DockerMenu = GObject.registerClass(
       // scrollView._getTopMenu = () => this.menu._getTopMenu();
 
       this.menu._section = new PopupMenuSection();
-      scrollView.add_actor(this.menu._section.actor);
+      scrollView.add_child(this.menu._section.actor);
 
       this.menu.box.add_child(scrollView);
 

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -216,7 +216,9 @@ export const DockerMenu = GObject.registerClass(
         });
 
         if (!this._containers.length) {
-          this.menu.addMenuItem(new PopupMenuItem("No containers detected"));
+          this.menu._section.addMenuItem(
+            new PopupMenuItem("No containers detected")
+          );
         }
       }
     }

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -206,7 +206,8 @@ export const DockerMenu = GObject.registerClass(
             container.project,
             container.name,
             container.status,
-            this.menu
+            this.menu,
+            this._refreshMenu,
           );
           const scrollView = subMenu.menu.actor;
           scrollView.set_mouse_scrolling(false);

--- a/src/dockerMenuItem.js
+++ b/src/dockerMenuItem.js
@@ -21,14 +21,14 @@ export const DockerMenuItem = GObject.registerClass(
     _dockerAction(containerName, dockerCommand) {
       Docker.runCommand(dockerCommand, containerName, (ok, command, err) => {
         if (ok) {
-          Main.notify("Command `" + command + "` successful");
+          Main.notify("Success", "Command `" + command + "` successful");
         } else {
           let errMsg = _("Error occurred when running `" + command + "`");
-          Main.notifyError(errMsg);
+          Main.notifyError("Error", errMsg);
           logError(err);
         }
       }).catch((err) => {
-        Main.notifyError(`${err}`);
+        Main.notifyError("Error", `${err}`);
         logError(err);
       });
     }

--- a/src/dockerMenuItem.js
+++ b/src/dockerMenuItem.js
@@ -21,7 +21,6 @@ export const DockerMenuItem = GObject.registerClass(
       );
     }
     _dockerAction(containerName, dockerCommand) {
-      this.
       Docker.runCommand(dockerCommand, containerName, (ok, command, err) => {
         if (ok) {
           Main.notify("Success", "Command `" + command + "` successful");

--- a/src/dockerMenuItem.js
+++ b/src/dockerMenuItem.js
@@ -8,8 +8,10 @@ import * as Docker from "./docker.js";
 // Docker actions for each container
 export const DockerMenuItem = GObject.registerClass(
   class DockerMenuItem extends PopupMenuItem {
-    _init(containerName, dockerCommand, icon) {
+    _init(containerName, dockerCommand, icon, refresh) {
       super._init(Docker.dockerCommandsToLabels[dockerCommand]);
+      this._refresh = refresh;
+
       if (icon) {
         this.insert_child_at_index(icon, 1);
       }
@@ -19,9 +21,11 @@ export const DockerMenuItem = GObject.registerClass(
       );
     }
     _dockerAction(containerName, dockerCommand) {
+      this.
       Docker.runCommand(dockerCommand, containerName, (ok, command, err) => {
         if (ok) {
           Main.notify("Success", "Command `" + command + "` successful");
+          this._refresh?.();
         } else {
           let errMsg = _("Error occurred when running `" + command + "`");
           Main.notifyError("Error", errMsg);

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -47,7 +47,13 @@ const getStatus = (statusMessage) => {
 // Menu entry representing a Docker container
 export const DockerSubMenu = GObject.registerClass(
   class DockerSubMenu extends PopupSubMenuMenuItem {
-    _init(projectName, containerName, containerStatusMessage, parentMenu) {
+    _init(
+      projectName,
+      containerName,
+      containerStatusMessage,
+      parentMenu,
+      refresh
+    ) {
       super._init(`${projectName}${projectName ? " ∘ " : ""}${containerName}`);
       this._parentMenu = parentMenu;
       switch (getStatus(containerStatusMessage)) {
@@ -61,7 +67,8 @@ export const DockerSubMenu = GObject.registerClass(
             new DockerMenuItem(
               containerName,
               "start",
-              menuIcon("docker-container-start-symbolic")
+              menuIcon("docker-container-start-symbolic"),
+              refresh
             )
           );
           break;
@@ -76,7 +83,8 @@ export const DockerSubMenu = GObject.registerClass(
             new DockerMenuItem(
               containerName,
               "pause",
-              menuIcon("docker-container-pause-symbolic")
+              menuIcon("docker-container-pause-symbolic"),
+              refresh
             )
           );
 
@@ -84,7 +92,8 @@ export const DockerSubMenu = GObject.registerClass(
             new DockerMenuItem(
               containerName,
               "stop",
-              menuIcon("docker-container-stop-symbolic")
+              menuIcon("docker-container-stop-symbolic"),
+              refresh
             )
           );
 
@@ -92,7 +101,8 @@ export const DockerSubMenu = GObject.registerClass(
             new DockerMenuItem(
               containerName,
               "restart",
-              menuIcon("docker-container-restart-symbolic")
+              menuIcon("docker-container-restart-symbolic"),
+              refresh
             )
           );
 
@@ -115,7 +125,8 @@ export const DockerSubMenu = GObject.registerClass(
             new DockerMenuItem(
               containerName,
               "unpause",
-              menuIcon("docker-container-start-symbolic")
+              menuIcon("docker-container-start-symbolic"),
+              refresh
             )
           );
           break;


### PR DESCRIPTION
This fixes the following bugs:
- the notify not working because of the title being required;
- runCommand not returning the promise, making it get a unhandled promise error instead of the actual one;
- `add_actor` not existing anymore;
- containers not updating after a command like stop/start;
- no containers message not disappearing after a container is created.