### PR TITLE
Fixed crash on not found terminal

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -29,7 +29,7 @@ export const hasPodman = !!GLib.find_program_in_path("podman");
 export const isUserInDockerGroup = (() => {
   const _userName = GLib.get_user_name();
   let _userGroups = GLib.ByteArray.toString(
-    GLib.spawn_command_line_sync("groups " + _userName)[1]
+    GLib.spawn_command_line_sync("groups " + _userName)[1],
   );
   let _inDockerGroup = false;
   if (_userGroups.match(/\sdocker[\s\n]/g)) _inDockerGroup = true; // Regex search for ' docker ' or ' docker' in Linux user's groups
@@ -72,8 +72,8 @@ export const getContainers = async () => {
 
   const containersInfo = await Promise.all(
     images.map(({ name }) =>
-      execCommand(["docker", "inspect", "-f", "{{json .Config.Labels}}", name])
-    )
+      execCommand(["docker", "inspect", "-f", "{{json .Config.Labels}}", name]),
+    ),
   );
   return containersInfo.map((commandOutput, i) => {
     const jsonOutput = JSON.parse(commandOutput);
@@ -143,10 +143,9 @@ export const runCommand = async (command, containerName, callback) => {
     cmd = ["x-terminal-emulator", "-e", "sh", "-c"];
   } else {
     const errMsg = `No valid terminal found (${Object.keys(validTerminals).join(
-      ", "
+      ", ",
     )})`;
     callback(false, command, errMsg);
-    logError(errMsg);
     return;
   }
 
@@ -179,7 +178,7 @@ export const runCommand = async (command, containerName, callback) => {
 export async function execCommand(
   argv,
   callback /*(status, command, err) */,
-  cancellable = null
+  cancellable = null,
 ) {
   try {
     // There is also a reusable Gio.SubprocessLauncher class available

--- a/src/docker.js
+++ b/src/docker.js
@@ -128,12 +128,15 @@ export const runCommand = async (command, containerName, callback) => {
   const validTerminals = {
     "x-terminal-emulator": !!GLib.find_program_in_path("x-terminal-emulator"),
     "gnome-terminal": !!GLib.find_program_in_path("gnome-terminal"),
+    ptyxis: !!GLib.find_program_in_path("ptyxis"),
     kgx: !!GLib.find_program_in_path("kgx"),
   };
 
   let cmd = [];
   if (validTerminals.kgx) {
     cmd = ["kgx", "-e"];
+  } else if (validTerminals.ptyxis) {
+    cmd = ["ptyxis", "--", "sh", "-c"];
   } else if (validTerminals["gnome-terminal"]) {
     cmd = ["gnome-terminal", "--", "sh", "-c"];
   } else if (validTerminals["x-terminal-emulator"]) {
@@ -142,8 +145,8 @@ export const runCommand = async (command, containerName, callback) => {
     const errMsg = `No valid terminal found (${Object.keys(validTerminals).join(
       ", "
     )})`;
-    Main.notify("Error", errMsg);
-    logError(err);
+    callback(false, command, errMsg);
+    logError(errMsg);
     return;
   }
 


### PR DESCRIPTION
If a terminal application was not found, the error was supposed to be output by notification and into log.
There I fixed two bugs:
- The notification uses Main which is not included in the file
- The error logging used `err` which was not defined.

Instead of the direct notification call and the call to logger I used the provided callback, which does both on error.
This fixes the [issue 58 I raised](https://github.com/RedSoftwareSystems/easy_docker_containers/issues/58).

## Summary by Sourcery

Fixes a crash when no valid terminal is found by using the provided callback to display an error message and log the error.

Bug Fixes:
- Fixes a crash that occurs when no valid terminal is found by using the provided callback to display an error message and log the error.
- Fixes an issue where the notification used `Main` which was not included in the file.
- Fixes an issue where the error logging used `err` which was not defined.

Enhancements:
- Adds support for the `ptyxis` terminal.