### PR TITLE
add bash to exec if available. If not, fallback to sh

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -164,7 +164,7 @@ export const runCommand = async (command, containerName, callback) => {
 
   switch (command[0]) {
     case "exec":
-      cmd = [...cmd, "'docker exec -it " + containerName + " sh; exec $SHELL'"];
+      cmd = [...cmd, "'docker exec -it " + containerName + " bash || docker exec -it " + containerName + " sh; exec $SHELL'"];
       GLib.spawn_command_line_async(cmd.join(" "));
       break;
     case "logs":


### PR DESCRIPTION
This commit improves the "Exec" action for containers in src/docker.js:167.

Before: The exec command always used sh as the shell inside the container.

After: It first tries bash, and only falls back to sh if bash isn't available.

## Summary by Sourcery

Update container exec action to prefer running an interactive bash shell and fall back to sh when bash is unavailable.