### PR TITLE
Feature/containers grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. _(The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).)_
 
+## [34] - 2026-06-05
+
+### Added
+
+- Add a preference to group Docker Compose services under one compose menu per compose file, with compose-level actions and a Services submenu for individual containers.
+- Show Docker Compose entries with a compose-specific icon and running/total service count.
+
+### Changed
+
+- Sort container menu entries automatically, with running containers before stopped containers and names sorted alphabetically within each state.
+- Sort grouped Compose entries automatically, with running or partially running groups before fully stopped groups and compose names sorted alphabetically within each state.
+- Enable Docker Compose service grouping by default.
+- Constrain the container menu height to the active monitor work area and show scrollbars only when needed.
+
 ## [33] - 2026-05-21
 
 ### Added

--- a/EXTENSIONS.GNOME.ORG.md
+++ b/EXTENSIONS.GNOME.ORG.md
@@ -1,4 +1,4 @@
-# Docker Containers
+# Easy Docker Containers
 
 This file contains in one place all the required data of the GNOME Shell extension for extensions.gnome.org website to make perfect control of them and keep it in every aspect the up-to-date extraction of main README document.
 
@@ -23,6 +23,10 @@ A GNOME Shell extension (GNOME Panel applet) to be able to generally control you
 
 The following actions are available from the GNOME Panel menu per Docker container:
 
+- START (COMPOSE) (Will start the services of the related compose project when available.)
+- STOP (COMPOSE) (Will stop the services of the related compose project when available.)
+- PAUSE (COMPOSE) (Will pause the services of the related compose project when available.)
+- RESTART (COMPOSE) (Will restart the services of the related compose project when available.)
 - START (Will start the container.)
 - STOP (Will stop the container.)
 - PAUSE (Will pause the container.)
@@ -30,10 +34,45 @@ The following actions are available from the GNOME Panel menu per Docker contain
 - EXEC (Will login to the running container interactively through your default terminal application.)
 - LOGS (Will start the running container's Docker logs in your default terminal application.)
 
+----- MENU ORGANIZATION PREFERENCES -----
+
+Container entries are sorted automatically, with running containers before stopped containers and names sorted alphabetically within each state.
+
+The extension preferences include container display options:
+
+- GROUP DOCKER COMPOSE SERVICES (Shows one compose menu per compose file, with compose-level actions and a Services submenu for individual containers.)
+
+When Docker Compose grouping is enabled, compose entries show the compose project name with a compose-specific icon, plus a running/total services count in the Services submenu. Running or partially running compose groups appear before fully stopped groups.
+
+----- DEVCONTAINER SUPPORT -----
+
+When a stopped container was created from a Dev Container workspace (i.e. the workspace folder contains a .devcontainer/devcontainer.json), the extension shows additional information and actions:
+
+- The devcontainer name (from devcontainer.json) is displayed as a subtitle under the container entry.
+- The workspace folder path is shown as a clickable item — clicking it opens a terminal at that folder.
+- START (Runs devcontainer up --workspace-folder <path> to start the container and apply all lifecycle commands.)
+- RECREATE AND START (Runs devcontainer up --remove-existing-container --workspace-folder <path> to destroy the existing container and create a fresh one from the image.)
+
+For running devcontainers, an additional action is available:
+
+- OPEN IN IDE (Runs the configured IDE command to attach your editor to the running container.)
+
+These actions require the devcontainer CLI to be installed and reachable on PATH (including version-manager-managed paths such as NVM or pyenv): https://github.com/devcontainers/cli
+
+Open in IDE command:
+
+Configure a shell command in the extension preferences (Devcontainer -> Open in IDE command) to attach your editor to a devcontainer. The command is triggered in two situations:
+
+- Clicking OPEN IN IDE on any running devcontainer.
+- Automatically after a successful RECREATE AND START (since recreation replaces the container ID, causing IDEs to lose their connection).
+
+Use %workspaceFolder% as a placeholder for the workspace folder path. Leave the field empty to skip this step entirely.
+
 ----- PREREQUISITE -----
 
 1. Properly installed and already running Docker service.
 2. Corresponding Linux user in `docker` Linux group for manage 'Docker' without `sudo` permission.
+3. (Devcontainer features only) devcontainer CLI installed and on PATH.
 
 ----- CREDITS -----
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ The following actions are available from the GNOME Panel menu per Docker contain
 - **Exec** _(Will login to the running container interactively through your default terminal application.)_
 - **Logs** _(Will start the running container's Docker logs in your default terminal application.)_
 
+### Menu organization preferences
+
+Container entries are sorted automatically, with running containers before stopped containers and names sorted alphabetically within each state.
+
+The extension preferences include container display options:
+
+- **Group Docker Compose services** _(Shows one compose menu per compose file, with compose-level actions and a **Services** submenu for individual containers.)_
+
+When Docker Compose grouping is enabled, compose entries show the compose project name with a compose-specific icon, plus a running/total services count in the **Services** submenu. Running or partially running compose groups appear before fully stopped groups.
+
 ### Devcontainer support
 
 When a stopped container was created from a [Dev Container](https://containers.dev/) workspace (i.e. the workspace folder contains a `.devcontainer/devcontainer.json`), the extension shows additional information and actions:
@@ -32,7 +42,7 @@ When a stopped container was created from a [Dev Container](https://containers.d
 
 For **running** devcontainers, an additional action is available:
 
-- **Open in IDE** _(Runs the configured IDE command to attach your editor to the running container — see [IDE command](#post-recreate-command-ide-reattachment) below.)_
+- **Open in IDE** _(Runs the configured IDE command to attach your editor to the running container — see [IDE command](#open-in-ide-command) below.)_
 
 > **Note:** these actions require the [`devcontainer` CLI](https://github.com/devcontainers/cli) to be installed and reachable on `PATH` (including version-manager-managed paths such as NVM or pyenv).
 
@@ -48,7 +58,7 @@ Use `%workspaceFolder%` as a placeholder for the workspace folder path. Examples
 | IDE | Command |
 |-----|---------|
 | VS Code / Cursor | `code --folder-uri "vscode-remote://dev-container+$(printf '%s' '%workspaceFolder%' \| od -An -tx1 \| tr -dc '[:xdigit:]')/workspaceFolder"` |
-| Zed | `zed %workspaceFolder%` _(Zed detects the devcontainer and prompts to reopen)_ |
+| Zed | `zed -n --dev-container %workspaceFolder%` _(Zed detects the devcontainer and prompts to reopen)_ |
 | IntelliJ / JetBrains | No CLI hook available — reconnect manually from inside the IDE. |
 
 Leave the field empty to skip this step entirely.

--- a/icons/docker-compose-symbolic.svg
+++ b/icons/docker-compose-symbolic.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 16 16"
+   height="16"
+   width="16"
+   fill="none">
+  <g id="layer1">
+    <!-- Layer 3 (Bottom) -->
+    <path
+       d="M 8,8.5 L 2.5,10.25 L 8,12 L 13.5,10.25 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 2,10.75 L 2,13.25 L 7.5,15 L 7.5,12.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 14,10.75 L 14,13.25 L 8.5,15 L 8.5,12.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+
+    <!-- Layer 2 (Middle) -->
+    <path
+       d="M 8,4.5 L 2.5,6.25 L 8,8 L 13.5,6.25 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 2,6.75 L 2,9.25 L 7.5,11 L 7.5,8.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 14,6.75 L 14,9.25 L 8.5,11 L 8.5,8.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+
+    <!-- Layer 1 (Top) -->
+    <path
+       d="M 8,0.5 L 2.5,2.25 L 8,4 L 13.5,2.25 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 2,2.75 L 2,5.25 L 7.5,7 L 7.5,4.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 14,2.75 L 14,5.25 L 8.5,7 L 8.5,4.5 Z"
+       style="fill:#deddda;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+</svg>

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "easy_docker_containers@red.software.systems",
   "description": "A GNOME Shell extension (GNOME Panel applet) to be able to generally control your available Docker containers.",
   "url": "https://github.com/RedSoftwareSystems/easy_docker_containers",
-  "version": 33,
+  "version": 34,
   "settings-schema": "org.gnome.shell.extensions.easy_docker_containers",
   "shell-version": ["45", "46", "47", "48", "49", "50"]
 }

--- a/prefs.js
+++ b/prefs.js
@@ -7,6 +7,7 @@ import {
 } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
 import { makePrefCouterGroup } from "./src/prefPages/dockerPrefCounter.js";
+import { makePrefContainersGroup } from "./src/prefPages/dockerPrefContainers.js";
 import { makePrefDevcontainerGroup } from "./src/prefPages/dockerPrefDevcontainer.js";
 
 const DOCKER_LOG_COMMAND =
@@ -115,6 +116,7 @@ export default class DockerContainersPreferences extends ExtensionPreferences {
     const settings = this.getSettings();
     const page = new Adw.PreferencesPage();
     page.add(makePrefCouterGroup(settings));
+    page.add(makePrefContainersGroup(settings));
     page.add(makePrefDevcontainerGroup(settings));
 
     window.add(page);

--- a/schemas/org.gnome.shell.extensions.easy_docker_containers.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.easy_docker_containers.gschema.xml
@@ -17,10 +17,10 @@
     <key name="counter-enabled" type="b">
        <default>true</default>
     </key>
-    <key name="sort-containers-by-name" type="b">
-      <default>false</default>
-      <summary>Sort containers by name</summary>
-      <description>When enabled, containers are shown alphabetically by name in the menu.</description>
+    <key name="group-compose-services" type="b">
+      <default>true</default>
+      <summary>Group Docker Compose services</summary>
+      <description>When enabled, services from the same compose file are grouped under one compose menu with a Services submenu.</description>
     </key>
     <key name="devcontainer-ide-command" type="s">
       <default>''</default>

--- a/schemas/org.gnome.shell.extensions.easy_docker_containers.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.easy_docker_containers.gschema.xml
@@ -17,6 +17,11 @@
     <key name="counter-enabled" type="b">
        <default>true</default>
     </key>
+    <key name="sort-containers-by-name" type="b">
+      <default>false</default>
+      <summary>Sort containers by name</summary>
+      <description>When enabled, containers are shown alphabetically by name in the menu.</description>
+    </key>
     <key name="devcontainer-ide-command" type="s">
       <default>''</default>
       <summary>Command to open a devcontainer in the configured IDE</summary>

--- a/src/dockerComposeServices.js
+++ b/src/dockerComposeServices.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const isContainerUp = (container) =>
+  container.status.indexOf("Paused") === -1 && container.status.indexOf("Up") > -1;
+
+const compareStrings = (a, b) => {
+  const baseCompare = a.localeCompare(b, undefined, { sensitivity: "base" });
+  if (baseCompare !== 0) return baseCompare;
+
+  return a.localeCompare(b);
+};
+
+const compareStatus = (a, b) => Number(isContainerUp(b)) - Number(isContainerUp(a));
+
+const composeKey = (compose) => [
+  compose.project,
+  compose.configFiles,
+  compose.workingDir,
+].join("\u0000");
+
+const compareComposeGroups = (a, b) => {
+  const statusCompare = Number(b.running > 0) - Number(a.running > 0);
+  if (statusCompare !== 0) return statusCompare;
+
+  return compareStrings(getComposeLabel(a.compose), getComposeLabel(b.compose));
+};
+
+const compareByService = (a, b) => {
+  const statusCompare = compareStatus(a, b);
+  if (statusCompare !== 0) return statusCompare;
+
+  return compareStrings(a.compose.service, b.compose.service);
+};
+
+export const getComposeCommandParams = (compose) => [
+  "-f",
+  `${compose.configFiles}`,
+  "--project-directory",
+  `${compose.workingDir}`,
+  "-p",
+  `${compose.project}`,
+];
+
+export const getComposeLabel = (compose) => compose.project;
+
+export const groupComposeServices = (containers) => {
+  const groups = new Map();
+  const devcontainers = [];
+  const singles = [];
+
+  containers.forEach((container) => {
+    if (!container.compose) {
+      if (container.devcontainer) {
+        devcontainers.push(container);
+      } else {
+        singles.push(container);
+      }
+      return;
+    }
+
+    const key = composeKey(container.compose);
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        compose: container.compose,
+        services: [],
+        running: 0,
+        total: 0,
+      });
+    }
+
+    const group = groups.get(key);
+    group.services.push(container);
+    group.total += 1;
+    if (isContainerUp(container)) group.running += 1;
+  });
+
+  const grouped = Array.from(groups.values()).map((group) => ({
+    ...group,
+    services: [...group.services].sort(compareByService),
+  }));
+
+  grouped.sort(compareComposeGroups);
+
+  return { grouped, devcontainers, singles };
+};
+
+export const getComposeStatusClass = (running, total) => {
+  if (running === 0) return "status-compose-stopped";
+  if (running < total) return "status-compose-partial";
+  return "status-compose-running";
+};

--- a/src/dockerComposeSubMenuMenuItem.js
+++ b/src/dockerComposeSubMenuMenuItem.js
@@ -1,0 +1,178 @@
+"use strict";
+
+import Atk from "gi://Atk";
+import GObject from "gi://GObject";
+import {
+  PopupSeparatorMenuItem,
+  PopupSubMenuMenuItem,
+} from "resource:///org/gnome/shell/ui/popupMenu.js";
+import { DockerMenuItem } from "./dockerMenuItem.js";
+import { DockerSubMenu } from "./dockerSubMenuMenuItem.js";
+import { menuIcon } from "./dockerMenuIcons.js";
+import {
+  getComposeCommandParams,
+  getComposeLabel,
+  getComposeStatusClass,
+} from "./dockerComposeServices.js";
+
+const isPaused = (container) => container.status.indexOf("Paused") > -1;
+
+const DockerMenuItemLabel = {
+  start: "Start",
+  restart: "Restart",
+  stop: "Stop",
+  pause: "Pause",
+  unpause: "Unpause",
+};
+
+const addComposeAction = (menu, compose, command, iconName, closePopup) => {
+  menu.addMenuItem(
+    new DockerMenuItem(
+      null,
+      [`compose ${command}`, ...getComposeCommandParams(compose)],
+      menuIcon(iconName),
+      closePopup,
+      DockerMenuItemLabel[command]
+    )
+  );
+};
+
+const NestedSubMenuMenuItem = GObject.registerClass(
+  class NestedSubMenuMenuItem extends PopupSubMenuMenuItem {
+    _init(text) {
+      super._init(text);
+      this._openedSubMenu = null;
+    }
+
+    _setOpenedSubMenu(submenu, closingSubmenu = null) {
+      if (!submenu) {
+        if (!closingSubmenu || this._openedSubMenu === closingSubmenu)
+          this._openedSubMenu = null;
+        return;
+      }
+
+      if (this._openedSubMenu && this._openedSubMenu !== submenu)
+        this._openedSubMenu.close(true);
+
+      this._openedSubMenu = submenu;
+    }
+
+    _subMenuOpenStateChanged(_menu, open) {
+      if (open) {
+        this.add_style_pseudo_class("open");
+        this.add_accessible_state(Atk.StateType.EXPANDED);
+        this.add_style_pseudo_class("checked");
+      } else {
+        this.remove_style_pseudo_class("open");
+        this.remove_accessible_state(Atk.StateType.EXPANDED);
+        this.remove_style_pseudo_class("checked");
+      }
+    }
+  }
+);
+
+// Menu entry representing one Docker Compose project/file.
+export const DockerComposeSubMenu = GObject.registerClass(
+  class DockerComposeSubMenu extends PopupSubMenuMenuItem {
+    _init(group, parentMenu, closePopup) {
+      super._init(`${getComposeLabel(group.compose)} ${group.running}/${group.total}`);
+      this._parentMenu = parentMenu;
+
+      this.insert_child_at_index(
+        menuIcon(
+          "docker-compose-symbolic",
+          getComposeStatusClass(group.running, group.total)
+        ),
+        1
+      );
+
+      this._addComposeActions(group, closePopup);
+      this.menu.addMenuItem(new PopupSeparatorMenuItem());
+      this._addServicesMenu(group, closePopup);
+    }
+
+    _addComposeActions(group, closePopup) {
+      const { compose, running, total, services } = group;
+      const paused = services.filter(isPaused).length;
+
+      if (running === 0) {
+        addComposeAction(
+          this.menu,
+          compose,
+          paused === total ? "unpause" : "start",
+          "docker-container-start-symbolic",
+          closePopup
+        );
+        return;
+      }
+
+      if (running === total) {
+        addComposeAction(
+          this.menu,
+          compose,
+          "pause",
+          "docker-container-pause-symbolic",
+          closePopup
+        );
+      } else {
+        addComposeAction(
+          this.menu,
+          compose,
+          "start",
+          "docker-container-start-symbolic",
+          closePopup
+        );
+      }
+
+      addComposeAction(
+        this.menu,
+        compose,
+        "stop",
+        "docker-container-stop-symbolic",
+        closePopup
+      );
+      addComposeAction(
+        this.menu,
+        compose,
+        "restart",
+        "docker-container-restart-symbolic",
+        closePopup
+      );
+    }
+
+    _addServicesMenu(group, closePopup) {
+      const servicesMenu = new NestedSubMenuMenuItem("Services");
+      servicesMenu.menu.actor.set_mouse_scrolling(false);
+      servicesMenu.menu.actor.set_overlay_scrollbars(true);
+      servicesMenu.insert_child_at_index(
+        menuIcon(
+          "docker-container-symbolic",
+          getComposeStatusClass(group.running, group.total)
+        ),
+        1
+      );
+
+      group.services.forEach((service) => {
+        servicesMenu.menu.addMenuItem(
+          new DockerSubMenu(
+            null,
+            service.devcontainer,
+            service.name,
+            service.status,
+            this._parentMenu,
+            closePopup,
+            service.compose.service,
+            true,
+            servicesMenu
+          )
+        );
+      });
+
+      this.menu.addMenuItem(servicesMenu);
+    }
+
+    _getTopMenu() {
+      return this._parentMenu?._getTopMenu() || super._getTopMenu();
+    }
+  }
+);

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -15,6 +15,13 @@ import { DockerSubMenu } from "./dockerSubMenuMenuItem.js";
 
 const isContainerUp = (container) => container.status.indexOf("Up") > -1;
 
+const compareContainersByName = (a, b) => {
+  const nameCompare = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  if (nameCompare !== 0) return nameCompare;
+
+  return a.name.localeCompare(b.name);
+};
+
 // Docker icon as panel menu
 export const DockerMenu = GObject.registerClass(
   class DockerMenu extends panelMenu.Button {
@@ -33,7 +40,13 @@ export const DockerMenu = GObject.registerClass(
       this._counterEnabled = this.settings.get_boolean("counter-enabled");
       this._counterFontSize = this.settings.get_int("counter-font-size");
       this._refreshDelay = this.settings.get_int("refresh-delay");
+      this._sortContainersByName = this.settings.get_boolean("sort-containers-by-name");
       this.settings.connect("changed::refresh-delay", this._refreshCount);
+      this.settings.connect("changed::sort-containers-by-name", () => {
+        this._sortContainersByName = this.settings.get_boolean("sort-containers-by-name");
+        this._containers = null;
+        this._refreshMenu();
+      });
 
       // Custom Docker icon as menu button
       const hbox = new St.BoxLayout({ style_class: "panel-status-menu-box" });
@@ -108,6 +121,12 @@ export const DockerMenu = GObject.registerClass(
       this._refreshCount();
     }
 
+    _sortContainers(containers) {
+      if (!this._sortContainersByName) return containers;
+
+      return [...containers].sort(compareContainersByName);
+    }
+
     _updateCountLabel(count) {
       if (
         this._counterEnabled &&
@@ -125,7 +144,7 @@ export const DockerMenu = GObject.registerClass(
       if (!this.menu.isOpen) return;
       try {
         await this._check();
-        const containers = await Docker.getContainers();
+        const containers = this._sortContainers(await Docker.getContainers());
         this._updateCountLabel(
           containers.filter((container) => isContainerUp(container)).length
         );

--- a/src/dockerMenu.js
+++ b/src/dockerMenu.js
@@ -4,22 +4,37 @@ import GLib from "gi://GLib";
 import St from "gi://St";
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import * as Docker from "./docker.js";
 import {
   PopupMenuItem,
   PopupMenuSection,
+  PopupSeparatorMenuItem,
 } from "resource:///org/gnome/shell/ui/popupMenu.js";
 import * as panelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 import { getExtensionObject } from "../extension.js";
 import { DockerSubMenu } from "./dockerSubMenuMenuItem.js";
+import { DockerComposeSubMenu } from "./dockerComposeSubMenuMenuItem.js";
+import { groupComposeServices } from "./dockerComposeServices.js";
 
-const isContainerUp = (container) => container.status.indexOf("Up") > -1;
+const getContainerState = (container) => {
+  if (container.status.indexOf("Paused") > -1) return "paused";
+  if (container.status.indexOf("Up") > -1) return "running";
+  return "stopped";
+};
 
-const compareContainersByName = (a, b) => {
-  const nameCompare = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-  if (nameCompare !== 0) return nameCompare;
+const isContainerUp = (container) => getContainerState(container) === "running";
 
-  return a.name.localeCompare(b.name);
+const compareStrings = (a, b) => {
+  const baseCompare = a.localeCompare(b, undefined, { sensitivity: "base" });
+  if (baseCompare !== 0) return baseCompare;
+
+  return a.localeCompare(b);
+};
+
+const compareContainers = (a, b) => {
+
+  return compareStrings(a.devcontainer?.name ?? a.name, b.devcontainer?.name ?? b.name);
 };
 
 // Docker icon as panel menu
@@ -31,7 +46,13 @@ export const DockerMenu = GObject.registerClass(
       this._refreshMenu = this._refreshMenu.bind(this);
       this._feedMenu = this._feedMenu.bind(this);
       this._updateCountLabel = this._updateCountLabel.bind(this);
+      this._syncScrollViewMaxHeight = this._syncScrollViewMaxHeight.bind(this);
+      this._syncScrollbarPolicy = this._syncScrollbarPolicy.bind(this);
+      this._scheduleScrollbarPolicySync = this._scheduleScrollbarPolicySync.bind(this);
       this._timeout = null;
+      this._startupRefreshId = null;
+      this._scrollbarPolicyTimeoutId = null;
+      this._maxScrollHeight = 0;
       this._destroyed = false;
       this.settings = getExtensionObject().getSettings(
         "org.gnome.shell.extensions.easy_docker_containers"
@@ -40,10 +61,10 @@ export const DockerMenu = GObject.registerClass(
       this._counterEnabled = this.settings.get_boolean("counter-enabled");
       this._counterFontSize = this.settings.get_int("counter-font-size");
       this._refreshDelay = this.settings.get_int("refresh-delay");
-      this._sortContainersByName = this.settings.get_boolean("sort-containers-by-name");
+      this._groupComposeServices = this.settings.get_boolean("group-compose-services");
       this.settings.connect("changed::refresh-delay", this._refreshCount);
-      this.settings.connect("changed::sort-containers-by-name", () => {
-        this._sortContainersByName = this.settings.get_boolean("sort-containers-by-name");
+      this.settings.connect("changed::group-compose-services", () => {
+        this._groupComposeServices = this.settings.get_boolean("group-compose-services");
         this._containers = null;
         this._refreshMenu();
       });
@@ -73,32 +94,44 @@ export const DockerMenu = GObject.registerClass(
 
       this.add_child(hbox);
 
-      const scrollView = new St.ScrollView();
+      this._scrollView = new St.ScrollView({
+        hscrollbar_policy: St.PolicyType.NEVER,
+        vscrollbar_policy: St.PolicyType.NEVER,
+        overlay_scrollbars: true,
+        enable_mouse_scrolling: true,
+        style_class: "vfade",
+      });
       this.menu._section = new PopupMenuSection();
-      if (scrollView.add_actor) {
-        scrollView.add_actor(this.menu._section.actor);
+      this.menu._section.actor.connect(
+        "notify::height",
+        this._scheduleScrollbarPolicySync
+      );
+      if (this._scrollView.add_actor) {
+        this._scrollView.add_actor(this.menu._section.actor);
       } else {
-        scrollView.add_child(this.menu._section.actor);
+        this._scrollView.add_child(this.menu._section.actor);
       }
-      this.menu.box.add_child(scrollView);
+      this.menu.box.add_child(this._scrollView);
 
-      this.menu.connect("open-state-changed", this._refreshMenu.bind(this));
+      this.menu.connect("open-state-changed", (_menu, open) => {
+        if (open) this._syncScrollViewMaxHeight();
+        this._refreshMenu();
+      });
 
       this.menu._section.addMenuItem(new PopupMenuItem(loading));
 
-      // Defer the first docker ps call by 5 s so it does not compete with
-      // GNOME Shell's own startup work. The counter will show "Loading…" until
-      // the timeout fires, which is preferable to stalling the shell.
-      this._timeout = GLib.timeout_add_seconds(
-        GLib.PRIORITY_DEFAULT_IDLE,
-        5,
-        () => {
-          this._timeout = null;
-          if (!this._destroyed)
-            this._refreshCount();
-          return GLib.SOURCE_REMOVE;
-        }
-      );
+      if (this._counterEnabled && this._refreshDelay > 0 && this._counterFontSize > 0) {
+        this._startupRefreshId = GLib.timeout_add_seconds(
+          GLib.PRIORITY_LOW,
+          5,
+          () => {
+            this._startupRefreshId = null;
+            if (!this._destroyed)
+              this._refreshCount();
+            return GLib.SOURCE_REMOVE;
+          }
+        );
+      }
       if (Docker.hasPodman() || Docker.hasDocker()) {
         this.show();
       }
@@ -112,6 +145,15 @@ export const DockerMenu = GObject.registerClass(
     destroy() {
       this._destroyed = true;
       this.clearLoop();
+      if (this._startupRefreshId) {
+        GLib.source_remove(this._startupRefreshId);
+        this._startupRefreshId = null;
+      }
+
+      if (this._scrollbarPolicyTimeoutId) {
+        GLib.source_remove(this._scrollbarPolicyTimeoutId);
+        this._scrollbarPolicyTimeoutId = null;
+      }
       super.destroy();
     }
 
@@ -121,10 +163,93 @@ export const DockerMenu = GObject.registerClass(
       this._refreshCount();
     }
 
-    _sortContainers(containers) {
-      if (!this._sortContainersByName) return containers;
+    _syncScrollViewMaxHeight() {
+      if (!this._scrollView) return;
 
-      return [...containers].sort(compareContainersByName);
+      const monitorIndex = Main.layoutManager.findIndexForActor(this);
+      const workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
+      const workAreaBottom = workArea.y + workArea.height;
+      const edgePadding = 12;
+      const fallbackTop = workArea.y + 32;
+      const [, scrollTop] = this._scrollView.get_transformed_position();
+      const scrollViewTop = Number.isFinite(scrollTop) && scrollTop > workArea.y
+        ? scrollTop
+        : fallbackTop;
+      const maxHeight = Math.max(
+        1,
+        Math.floor(workAreaBottom - scrollViewTop - edgePadding)
+      );
+
+      this._maxScrollHeight = maxHeight;
+      this._scrollView.style = `max-height: ${maxHeight}px;`;
+    }
+
+    _syncScrollbarPolicy() {
+      if (!this._scrollView || !this.menu._section?.actor) return;
+
+      this._syncScrollViewMaxHeight();
+
+      const [, naturalHeight] = this.menu._section.actor.get_preferred_height(-1);
+      const needsScrollbar =
+        this._maxScrollHeight > 0 && naturalHeight > this._maxScrollHeight;
+
+      this._scrollView.set_overlay_scrollbars(!needsScrollbar);
+      this._scrollView.vscrollbar_policy = needsScrollbar
+        ? St.PolicyType.AUTOMATIC
+        : St.PolicyType.NEVER;
+      this._scrollView.set_height(needsScrollbar ? this._maxScrollHeight : -1);
+    }
+
+    _scheduleScrollbarPolicySync() {
+      if (this._destroyed || !this._scrollView) return;
+
+      if (this._scrollbarPolicyTimeoutId)
+        GLib.source_remove(this._scrollbarPolicyTimeoutId);
+
+      this._scrollbarPolicyTimeoutId = GLib.timeout_add(
+        GLib.PRIORITY_DEFAULT_IDLE,
+        300,
+        () => {
+          this._scrollbarPolicyTimeoutId = null;
+          if (!this._destroyed)
+            this._syncScrollbarPolicy();
+          return GLib.SOURCE_REMOVE;
+        }
+      );
+    }
+
+    _sortContainers(containers) {
+      return [...containers].sort(compareContainers);
+    }
+
+    _getContainerMenuItems(containers, closePopup) {
+      return containers.map((container) =>
+        new DockerSubMenu(
+          container.compose,
+          container.devcontainer,
+          container.name,
+          container.status,
+          this.menu,
+          closePopup
+        )
+      );
+    }
+
+    _getGroupedMenuItems(containers, closePopup) {
+      const { grouped, devcontainers, singles } = groupComposeServices(containers);
+      const items = [];
+
+      const addGroup = (groupItems) => {
+        if (groupItems.length === 0) return;
+        if (items.length > 0) items.push(new PopupSeparatorMenuItem());
+        items.push(...groupItems);
+      };
+
+      addGroup(grouped.map((group) => new DockerComposeSubMenu(group, this.menu, closePopup)));
+      addGroup(this._getContainerMenuItems(singles, closePopup));
+      addGroup(this._getContainerMenuItems(devcontainers, closePopup));
+
+      return items;
     }
 
     _updateCountLabel(count) {
@@ -229,6 +354,7 @@ export const DockerMenu = GObject.registerClass(
       const anyRecreating = Docker.hasAnyRecreating();
       if (
         anyRecreating !== this._anyRecreating ||
+        this._groupComposeServices !== this._lastGroupComposeServices ||
         anyRecreating ||
         !this._containers ||
         dockerContainers.length !== this._containers.length ||
@@ -238,31 +364,39 @@ export const DockerMenu = GObject.registerClass(
           return (
             currContainer.project !== container.project ||
             currContainer.name !== container.name ||
+            getContainerState(currContainer) !== getContainerState(container) ||
+            currContainer.compose?.service !== container.compose?.service ||
+            currContainer.compose?.project !== container.compose?.project ||
+            currContainer.compose?.configFiles !== container.compose?.configFiles ||
+            currContainer.compose?.workingDir !== container.compose?.workingDir ||
             currContainer.devcontainer?.name !== container.devcontainer?.name ||
             currContainer.devcontainer?.localFolder !==
-            container.devcontainer?.localFolder ||
-            isContainerUp(currContainer) !== isContainerUp(container)
+            container.devcontainer?.localFolder
           );
         })
       ) {
         this._anyRecreating = anyRecreating;
+        this._lastGroupComposeServices = this._groupComposeServices;
         this.menu._section.removeAll();
         this._containers = dockerContainers;
-        this._containers.forEach((container) => {
-          const subMenu = new DockerSubMenu(
-            container.compose,
-            container.devcontainer,
-            container.name,
-            container.status,
-            this.menu,
-            () => {
-              this.menu.close();
-            }
-          );
-          const scrollView = subMenu.menu.actor;
-          scrollView.set_mouse_scrolling(false);
-          scrollView.set_overlay_scrollbars(false);
-          this.menu._section.addMenuItem(subMenu);
+        const closePopup = () => {
+          this.menu.close();
+        };
+        const menuItems = this._groupComposeServices
+          ? this._getGroupedMenuItems(this._containers, closePopup)
+          : this._getContainerMenuItems(this._containers, closePopup);
+
+        menuItems.forEach((item) => {
+          if (item.menu) {
+            const scrollView = item.menu.actor;
+            scrollView.set_mouse_scrolling(false);
+            scrollView.set_overlay_scrollbars(true);
+            item.menu.connect(
+              "open-state-changed",
+              this._scheduleScrollbarPolicySync
+            );
+          }
+          this.menu._section.addMenuItem(item);
         });
 
         if (!this._containers.length) {
@@ -270,6 +404,8 @@ export const DockerMenu = GObject.registerClass(
             new PopupMenuItem("No containers detected")
           );
         }
+
+        this._syncScrollbarPolicy();
       }
     }
   }

--- a/src/dockerMenuIcons.js
+++ b/src/dockerMenuIcons.js
@@ -1,0 +1,20 @@
+"use strict";
+
+import St from "gi://St";
+import Gio from "gi://Gio";
+import { getExtensionObject } from "../extension.js";
+
+export const gioIcon = (name = "docker-container-unavailable-symbolic") =>
+  Gio.icon_new_for_string(
+    getExtensionObject().path + "/icons/" + name + ".svg"
+  );
+
+export const menuIcon = (
+  name = "docker-container-unavailable-symbolic",
+  styleClass = "system-status-icon"
+) =>
+  new St.Icon({
+    gicon: gioIcon(name),
+    style_class: styleClass,
+    icon_size: "16",
+  });

--- a/src/dockerMenuItem.js
+++ b/src/dockerMenuItem.js
@@ -8,9 +8,9 @@ import * as Docker from "./docker.js";
 // Docker actions for each container
 export const DockerMenuItem = GObject.registerClass(
   class DockerMenuItem extends PopupMenuItem {
-    _init(containerName, dockerCommand, icon, closePopup) {
+    _init(containerName, dockerCommand, icon, closePopup, labelOverride = null) {
       const commandName = [dockerCommand].flat()[0];
-      super._init(Docker.dockerCommandsToLabels[commandName]);
+      super._init(labelOverride || Docker.dockerCommandsToLabels[commandName]);
       this._closePopup = closePopup;
 
       if (icon) {

--- a/src/dockerSubMenuMenuItem.js
+++ b/src/dockerSubMenuMenuItem.js
@@ -1,8 +1,8 @@
 "use strict";
 
+import Atk from "gi://Atk";
 import Clutter from "gi://Clutter";
 import St from "gi://St";
-import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 import { Spinner } from "resource:///org/gnome/shell/ui/animation.js";
 import {
@@ -12,29 +12,7 @@ import {
 } from "resource:///org/gnome/shell/ui/popupMenu.js";
 import { DockerMenuItem, DevcontainerStartMenuItem, DevcontainerRecreateMenuItem, DevcontainerOpenInIDEMenuItem } from "./dockerMenuItem.js";
 import * as Docker from "./docker.js";
-import { getExtensionObject } from "../extension.js";
-
-/**
- * Create Gio.icon based St.Icon
- *
- * @param {String} name The name of the icon (filename without extension)
- * @param {String} styleClass The style of the icon
- *
- * @return {Object} an St.Icon instance
- */
-const gioIcon = (name = "docker-container-unavailable-symbolic") =>
-  Gio.icon_new_for_string(
-    getExtensionObject().path + "/icons/" + name + ".svg"
-  );
-const menuIcon = (
-  name = "docker-container-unavailable-symbolic",
-  styleClass = "system-status-icon"
-) =>
-  new St.Icon({
-    gicon: gioIcon(name),
-    style_class: styleClass,
-    icon_size: "16",
-  });
+import { menuIcon } from "./dockerMenuIcons.js";
 
 /**
  * Get the status of a container from the status message obtained with the docker command
@@ -51,8 +29,8 @@ const getStatus = (statusMessage) => {
   return status;
 };
 
-const getMenuLabel = (compose, containerName) =>
-  compose ? `${compose.project} ∘ ${compose.service}` : containerName;
+const getMenuLabel = (compose, containerName, labelOverride = null) =>
+  labelOverride || (compose ? `${compose.project} ∘ ${compose.service}` : containerName);
 
 // Menu entry representing a Docker container
 export const DockerSubMenu = GObject.registerClass(
@@ -63,10 +41,15 @@ export const DockerSubMenu = GObject.registerClass(
       containerName,
       containerStatusMessage,
       parentMenu,
-      closePopup
+      closePopup,
+      labelOverride = null,
+      nested = false,
+      nestedOwner = null
     ) {
-      super._init(getMenuLabel(compose, containerName));
+      super._init(getMenuLabel(compose, containerName, labelOverride));
       this._parentMenu = parentMenu;
+      this._nested = nested;
+      this._nestedOwner = nestedOwner;
 
       // Store data needed for re-rendering the recreating state later.
       this._devcontainer = devcontainer;
@@ -280,7 +263,7 @@ export const DockerSubMenu = GObject.registerClass(
             this.menu.addMenuItem(
               new DockerMenuItem(
                 containerName,
-                ["compose unpause"],
+                ["compose unpause", ...composeParams],
                 menuIcon("docker-container-start-symbolic"),
                 closePopup
               )
@@ -374,6 +357,25 @@ export const DockerSubMenu = GObject.registerClass(
           this._closePopup
         )
       );
+    }
+
+    _subMenuOpenStateChanged(menu, open) {
+      if (!this._nested) {
+        super._subMenuOpenStateChanged(menu, open);
+        return;
+      }
+
+      if (open) {
+        this.add_style_pseudo_class("open");
+        this._nestedOwner?._setOpenedSubMenu(menu);
+        this.add_accessible_state(Atk.StateType.EXPANDED);
+        this.add_style_pseudo_class("checked");
+      } else {
+        this.remove_style_pseudo_class("open");
+        this._nestedOwner?._setOpenedSubMenu(null, menu);
+        this.remove_accessible_state(Atk.StateType.EXPANDED);
+        this.remove_style_pseudo_class("checked");
+      }
     }
 
     _getTopMenu() {

--- a/src/prefPages/dockerPrefContainers.js
+++ b/src/prefPages/dockerPrefContainers.js
@@ -11,9 +11,9 @@ export function makePrefContainersGroup(settings) {
   libs.makeSwitch({
     parent,
     settings,
-    title: _("Sort by name"),
-    subtitle: _("Show containers alphabetically in the menu"),
-    settingsProperty: "sort-containers-by-name",
+    title: _("Group containers by type"),
+    subtitle: _("Separate containers into Docker Compose projects, single instances, and devcontainers — each group divided by a separator"),
+    settingsProperty: "group-compose-services",
   });
 
   return parent;

--- a/src/prefPages/dockerPrefContainers.js
+++ b/src/prefPages/dockerPrefContainers.js
@@ -1,0 +1,20 @@
+import Adw from "gi://Adw";
+import {
+  gettext as _,
+} from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+
+import * as libs from "./libs.js";
+
+export function makePrefContainersGroup(settings) {
+  const parent = new Adw.PreferencesGroup({ title: _("Containers") });
+
+  libs.makeSwitch({
+    parent,
+    settings,
+    title: _("Sort by name"),
+    subtitle: _("Show containers alphabetically in the menu"),
+    settingsProperty: "sort-containers-by-name",
+  });
+
+  return parent;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,17 +1,29 @@
 /* Container icon colors */
 
 .status-undefined {
-	color: #9e9e9e;
+    color: #9e9e9e;
 }
 
 .status-stopped {
-	color: #ff3d00;
+    color: #ff3d00;
 }
 
 .status-running {
-	color: #00c853;
+    color: #00c853;
+}
+
+.status-compose-stopped {
+    color: #ff3d00;
+}
+
+.status-compose-partial {
+    color: #ffab00;
+}
+
+.status-compose-running {
+    color: #00c853;
 }
 
 .status-paused {
-	color: #00b0ff;
+    color: #00b0ff;
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce grouped Docker Compose project menus with improved container sorting and menu scrolling behavior.

New Features:
- Add optional grouping of Docker Compose services under a single compose menu entry with compose-level actions and a Services submenu for individual containers.
- Introduce dedicated Docker Compose project submenu items with compose-specific icons and running/total service counts.
- Add a Containers preferences section to control whether Docker Compose services are grouped in the menu.

Enhancements:
- Sort containers and compose groups consistently by state and name to keep the menu organized.
- Constrain the Docker menu height to the active monitor work area and only show scrollbars when necessary.
- Extract shared icon creation helpers into a reusable dockerMenuIcons module.
- Improve submenu open/close behavior and accessibility for nested service menus.

Documentation:
- Update README and GNOME Extensions metadata docs to describe compose grouping, menu organization preferences, and devcontainer IDE command changes.

Chores:
- Add schema key and default setting for Docker Compose service grouping.
- Update changelog for version 34 with compose grouping and menu layout changes.